### PR TITLE
Both bundle and vendor are created if using the described installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _site
+vendor
+.bundle
 .sass-cache
 .jekyll-metadata

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,8 @@ paginate: 5
 paginate_path: "page/:num"
 # Build settings
 markdown: kramdown
+# Exclude dirs
+exclude: [vendor]
 
 # Archive
 jekyll-archives:


### PR DESCRIPTION
I think these should be merged for someone who who doesn't have jekyll and bundle installed and decides to contribute(like me :sweat_smile: )  
Installing using the README gives the two directories and also throws an error if by chance vendor is included by jekyll
