### PR TITLE
Tags look better

### DIFF
--- a/assets/css/alternative.css
+++ b/assets/css/alternative.css
@@ -305,6 +305,10 @@ ul {
   visibility: hidden;
 }
 
+.tags-pagee ul {
+  list-style-type: none;
+}
+
 .tags li {
   position: relative;
   float: left;

--- a/tags.html
+++ b/tags.html
@@ -7,8 +7,8 @@ exclude_from_nav: true
 
 <div style="margin: 2rem auto;">
 <div class="tags-pagee">
-<ul class="tags" style="padding:0     margin-bottom: 20px;">
-	  {% for tag in site.tags %}
+<ul class="tags" style="padding:0; margin-top: 20px; margin-bottom: 20px;">
+{% for tag in site.tags %}
   <li style="font-size: {{ tag | last | size | times: 100 | divided_by: site.tags.size | plus: 70  }}%">
     <a id="route" href="#{{ tag | first | slugize }}">
       {{ tag | first }}


### PR DESCRIPTION
Earlier it used to look like this:  
![earlier](https://cloud.githubusercontent.com/assets/10435324/15090805/3809a2aa-1452-11e6-8a71-c6dfe897a0cd.png)  

Now :  
![new](https://cloud.githubusercontent.com/assets/10435324/15090807/560514ec-1452-11e6-8de0-fb9be729a634.png)
