### PR TITLE
Tried fixing for https

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -98,7 +98,7 @@ layout: default
   (function () {
     var s = document.createElement('script'); s.async = true;
     s.type = 'text/javascript';
-    s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+    s.src = '//' + disqus_shortname + '.disqus.com/count.js';
     (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
   }());
 </script>


### PR DESCRIPTION
The console was showing error for mixed content, i.e.,
http content in a https site. My offline jekyll creates
http and hence the script worked offline. I have now
changed the explicit http in `count.js` to nothing,
similar to the one being used in `embed.js`. Let's hope
this works
