### PR TITLE
Added support for Github Flavoured Markdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,3 +40,8 @@ jekyll-archives:
     day: '/:year/:month/:day/'
     tag: '/tag/:name/'
     category: '/category/:name/'
+
+# Kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false

--- a/assets/css/alternative.css
+++ b/assets/css/alternative.css
@@ -1861,7 +1861,7 @@ ul {
 }
 
 .highlighter-rouge .highlight {
-  background: #eef;
+  background: #222;
 }
 
 .highlight .c {


### PR DESCRIPTION
Github flavoured markdown is the most common markdown syntax out
there.
- It has easier syntax for code highlighting, i.e., triple
  backticks followed by language name as compared to what we
  are using currently
- Easier strikethrough by using double ~

Modified in such a way that the current posts remain the same and
the future posts can handle GFM.
